### PR TITLE
InvalidatingCoreAnimation was not being setup properly

### DIFF
--- a/src/NpapiPlugin/Mac/NpapiPluginMac.mm
+++ b/src/NpapiPlugin/Mac/NpapiPluginMac.mm
@@ -259,6 +259,16 @@ NpapiPluginMac::NpapiPluginMac(const FB::Npapi::NpapiBrowserHostPtr &host, const
     if(enableInvalidatingCoreAnimation(host)) {
         m_eventModel = EventModelCocoa;
         m_drawingModel = DrawingModelInvalidatingCoreAnimation;
+#if FBMAC_USE_COCOA && FBMAC_USE_COREANIMATION
+        // This hack exists to allow the plugin to call setLayer() on 
+        // the newly created PluginWindowMacCocoaCA window. This must
+        // be done before SetWindowCA() since the browser will call
+        // GetValue() for the CALayer before it calls SetWindow.
+        PluginWindowMacCocoaICA* pluginWinICA = getFactoryInstance()->createPluginWindowCocoaICA();
+        this->pluginWin = static_cast<PluginWindow*>(pluginWinICA);
+        pluginWinICA->setNpHost(m_npHost);
+        pluginMain->SetWindow(pluginWinICA);
+#endif
     } else if(enableCoreAnimation(host)) {
         m_eventModel   = EventModelCocoa;
         m_drawingModel = DrawingModelCoreAnimation;
@@ -588,7 +598,7 @@ int16_t NpapiPluginMac::HandleEvent(void* event)
 int16_t NpapiPluginMac::GetValue(NPPVariable variable, void *value) {
 #if FBMAC_USE_COREANIMATION
     if(variable == NPPVpluginCoreAnimationLayer) {
-        if(m_drawingModel == DrawingModelCoreAnimation) {
+        if(m_drawingModel == DrawingModelCoreAnimation || m_drawingModel == DrawingModelInvalidatingCoreAnimation) {
             PluginWindowMacCocoaCA* win = static_cast<PluginWindowMacCocoaCA*>(pluginWin);
             if(win != NULL) {
                 *((CALayer **)value) = (CALayer*)win->getLayer();


### PR DESCRIPTION
ICA now follows the same workflow as CoreAnimation (set window, get layer from plugin, send to browser).
