### PR TITLE
IE8 exception when using <object> in LightBox

### DIFF
--- a/src/ActiveXCore/FBControl.h
+++ b/src/ActiveXCore/FBControl.h
@@ -330,7 +330,9 @@ namespace FB {
                 pluginWin = getFactoryInstance()->createPluginWindowWin(FB::WindowContextWin(m_hWnd));
                 static_cast<PluginWindowWin*>(pluginWin)->setCallOldWinProc(true);
             }
-            pluginMain->SetWindow(pluginWin);
+            if (pluginMain) {
+                pluginMain->SetWindow(pluginWin);
+            }
 
             return hr;
         }


### PR DESCRIPTION
I got an exception after using FireBreath plugin inside of a javascript LightBox. It seems that FireBreath would like to set a new window after closing the lightbox (and the removement of the plugin from the html page)

This little change fixes this issue for me.
