### PR TITLE
correct for when T is an unsigned 32-bit integer type

### DIFF
--- a/src/NpapiCore/NPVariantUtil.h
+++ b/src/NpapiCore/NPVariantUtil.h
@@ -1,4 +1,3 @@
-
 /**********************************************************\
  Original Author: Georg Fritzsche
  
@@ -293,7 +292,7 @@ namespace FB { namespace Npapi
                 return &makeNPVariant<bool>;
             }
             
-            if ((sizeof(T) <= sizeof(int32_t)) || (boost::is_unsigned<T>::value && (sizeof(T) <= sizeof(int32_t)/2))) {
+            if ((boost::is_signed<T>::value && (sizeof(T) <= sizeof(int32_t))) || (boost::is_unsigned<T>::value && (sizeof(T) <= sizeof(int32_t)/2))) {
                 // max value of T fits into int32_t
                 return &makeNPVariant<int32_t>;
             }


### PR DESCRIPTION
problem is reproducible by firing an event like:

FB_JSAPI_EVENT(test, 1, (uint_32));

where the parameter is > 0x7fffffff
