### PR TITLE
detect disappearing async callback delegate

### DIFF
--- a/examples/FBTestPlugin/test.html
+++ b/examples/FBTestPlugin/test.html
@@ -246,6 +246,21 @@
             }
             plugin.testEvent("some string");
 
+            // now remove the async callback delegate,
+            // and trigger a callback
+            for (var i in window) {
+                if (0 == i.indexOf("__FB_CALL_")) {
+                    try {
+                        delete window[i];
+                        plugin.testEvent("die?");
+                    } catch (e) {
+                        // ie8, at least, is unhappy doing the delete,
+                        // but then, activex doesn't have this problem
+                    }
+                    break;
+               }
+            }
+
             try {
                 thread = plugin.createThreadRunner();
 

--- a/src/NpapiCore/NPObjectAPI.cpp
+++ b/src/NpapiCore/NPObjectAPI.cpp
@@ -338,6 +338,9 @@ void FB::Npapi::NPObjectAPI::callMultipleFunctions( const std::string& name, con
     // particularly in FF4.
     
     NPObjectAPIPtr d = static_pointer_cast<NPObjectAPI>(browser->getDelayedInvokeDelegate());
+    if (!d) {
+        throw FB::script_error("Error calling handlers (delegate disappeared)");
+    }
     NPObject* delegate(d->getNPObject());
 
     // Allocate the arguments


### PR DESCRIPTION
malicious/incompetent webpage can crash npapi plugins
