### PR TITLE
An extra set of quotes in common.cmd breaks prep scripts

### DIFF
--- a/common.cmd
+++ b/common.cmd
@@ -25,7 +25,7 @@ goto finish
 set PROJDIR="%RUN_FROM%\projects"
 
 :default_build
-IF /I "%PROJDIR%"=="examples" goto examples
+IF /I %PROJDIR%=="examples" goto examples
 set BUILDDIR="%RUN_FROM%\build"
 goto finish
 


### PR DESCRIPTION
If FireBreath is installed in a directory that uses spaces in its name (i.e. "C:\Projects\Cool Plugin\FireBreath\"), an extra set of spaces in common.cmd will break the prep scripts and fail to create project files.  Removing the quotes allows the script to run just fine.

The `%PROJDIR%` variable already has the directory encapsulated in quotes.  Adding additional quotes around the variable in the conditional negates any quotes that are there.  This won't affect systems using directory structures without spaces, but if spaces are used it causes problems.
