### PR TITLE
FIREBREATH-120: Add support for GTK+ 2.12

### DIFF
--- a/src/PluginAuto/X11/PluginWindowX11.cpp
+++ b/src/PluginAuto/X11/PluginWindowX11.cpp
@@ -267,7 +267,7 @@ gboolean PluginWindowX11::EventCallback(GtkWidget *widget, GdkEvent *event)
 
 GdkNativeWindow PluginWindowX11::getWindow()
 {
-  return GDK_WINDOW_XID(gtk_widget_get_window(m_canvas));
+  return GDK_WINDOW_XID(GTK_WIDGET(m_canvas)->window);
 }
 
 #endif


### PR DESCRIPTION
The old way needs GTK+ 2.14 version.
It may work with 2.08, but I have only tested with 2.12.
