### PR TITLE
FIREBREATH-120: Add support for GTK+ 2.12

### DIFF
--- a/src/PluginAuto/X11/PluginWindowX11.cpp
+++ b/src/PluginAuto/X11/PluginWindowX11.cpp
@@ -267,7 +267,11 @@ gboolean PluginWindowX11::EventCallback(GtkWidget *widget, GdkEvent *event)
 
 GdkNativeWindow PluginWindowX11::getWindow()
 {
+#if GTK_CHECK_VERSION(2, 14, 0)
+  return GDK_WINDOW_XID(gtk_widget_get_window(m_canvas));
+#else
   return GDK_WINDOW_XID(GTK_WIDGET(m_canvas)->window);
+#endif
 }
 
 #endif


### PR DESCRIPTION
Kalev pointed out that its deprecated to call public struct members.
However on old versions there aren't any other ways to do this.
