### PR TITLE
Make FB compile with newer Boost versions.

### DIFF
--- a/src/ActiveXCore/IDispatchAPI.cpp
+++ b/src/ActiveXCore/IDispatchAPI.cpp
@@ -27,7 +27,7 @@ using namespace FB::ActiveX;
 
 boost::shared_ptr<FB::ActiveX::IDispatchAPI> IDispatchAPI::create(IDispatch * obj, const ActiveXBrowserHostPtr& host)
 {
-    return boost::make_shared<IDispatchAPI>(obj, host);
+    return boost::shared_ptr<IDispatchAPI>(new IDispatchAPI(obj, host));
 }
 
 FB::ActiveX::IDispatchAPI::IDispatchAPI(IDispatch * obj, const ActiveXBrowserHostPtr& host) :

--- a/src/ActiveXCore/IDispatchAPI.h
+++ b/src/ActiveXCore/IDispatchAPI.h
@@ -99,7 +99,6 @@ namespace FB { namespace ActiveX {
         virtual FB::JSAPIPtr getJSAPI() const;
 
     private:
-        friend boost::shared_ptr<IDispatchAPI> boost::make_shared<IDispatchAPI>(IDispatch * const &, const ActiveXBrowserHostPtr&);
         IDispatchAPI(IDispatch *, const ActiveXBrowserHostPtr&);
     };
 } }


### PR DESCRIPTION
New Boost versions use new make_shared(.) variants with compilers supporting C++0x-rvalues (e.g. MSVC10). These cannot be made friend functions, while still supporting older compilers. To ensure compatibility make_shared is not used (for now).
