### PR TITLE
Added firing of MouseScrollEvent on Windows

### DIFF
--- a/src/PluginAuto/Win/PluginWindowWin.cpp
+++ b/src/PluginAuto/Win/PluginWindowWin.cpp
@@ -175,6 +175,14 @@ bool PluginWindowWin::WinProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam
                 return true;
             break;
         }
+        case WM_MOUSEWHEEL:
+        {
+            MouseScrollEvent ev(GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam),
+                                0, GET_WHEEL_DELTA_WPARAM(wParam));
+            if(SendEvent(&ev))
+                return true;
+            break;
+        }
         case WM_PAINT:
         {
             RefreshEvent ev;


### PR DESCRIPTION
I found that the MouseScrollEvent was not fired on Windows.

Adding the following case to the switch statement in
PluginWindowWin::WinProc solved this for me.

Notes:
- m_dx is always 0
- m_dy is set to the scroll wheel delta supplied by the Windows API (http://msdn.microsoft.com/en-us/library/windows/desktop/ms645617%28v=vs.85%29.aspx)
- Implementation still required for X11?
