### PR TITLE
change Mac template Info.plist to include FBSTRING_FileExtents

### DIFF
--- a/fbgen/src/Mac/bundle_template/Info.plist
+++ b/fbgen/src/Mac/bundle_template/Info.plist
@@ -49,7 +49,7 @@
 		<dict>
             <key>WebPluginExtensions</key>
             <array>
-                <string>${CUR_MIMETYPE}</string>
+                <string>${CUR_EXTENT}</string>
             </array>
 			<key>WebPluginTypeDescription</key>
 			<string>${CUR_DESC}</string>


### PR DESCRIPTION
include FBSTRING_FileExtents in Info.plist inside the plugin bundle template (Mac OS X)
