### PR TITLE
FIREBREATH-165: Fix FB::variant memory leaks

### DIFF
--- a/src/ScriptingCore/TypeIDMap.h
+++ b/src/ScriptingCore/TypeIDMap.h
@@ -37,7 +37,7 @@ namespace FB {
            public:
                bool operator()(const FB::variant &x, const FB::variant &y) const
                {
-                   return x.lessthan(y);
+                   return x < y;
                }
         };
 


### PR DESCRIPTION
Replace Diggins' variant with boost::any to fix leaks seen when re-assigning
std::string; the semantics of this class remains almost the same, the
differences being:
variant::cast() no longer returns references;
variant::lessthan() has been removed (use the < operator)
