### PR TITLE
Fix for compilation issue with boost 1.48+ on Mac

### DIFF
--- a/src/ScriptingCore/Util/meta_util_impl.h
+++ b/src/ScriptingCore/Util/meta_util_impl.h
@@ -17,6 +17,12 @@ Copyright 2009 Georg Fritzsche, Firebreath development team
 #define H_META_UTIL_IMPL_22122009
 
 #include <utility>
+
+//Workaround for conflict between boost 1.48+ and Apple's AssertMacros.h
+#ifdef check
+#undef check
+#endif
+
 #include <boost/utility/enable_if.hpp>
 #include <boost/mpl/equal_to.hpp>
 #include <boost/mpl/vector.hpp>


### PR DESCRIPTION
This is a fix for a an issue when compiling on Mac with boost 1.48+. There is a conflict between a macro defined both in boost and AssertMacros.h. There are several ways to solve the issue but we prefer this one because it also works when using a SDK older than 10.6. This issue and possible ways to fix it are explained in this thread:

http://stackoverflow.com/questions/8173620/c-boost-1-48-type-traits-and-cocoa-inclusion-weirdness

If you think this is acceptable, you might want to merge it in the master branch as well.
