### PR TITLE
NPP_NewStream - return NPERR_NO_DATA instead of NPERR_NO_ERROR when a (e.g. unsolicited) stream won't be handled by the plugin

### DIFF
--- a/src/NpapiCore/NpapiPlugin.cpp
+++ b/src/NpapiCore/NpapiPlugin.cpp
@@ -311,7 +311,7 @@ NPError NpapiPlugin::NewStream(NPMIMEType type, NPStream* stream, NPBool seekabl
 {
     NpapiStream* s = static_cast<NpapiStream*>( stream->notifyData );
     // check for streams we did not request or create
-    if ( !s ) return NPERR_NO_ERROR;
+    if ( !s ) return NPERR_NO_DATA;
 
     s->setMimeType( type );
     s->setStream( stream );


### PR DESCRIPTION
Returning NPERR_NO_ERROR causes the browser to cache the data and to call NPP_WriteReady over and over again as it assumes there will be a point where the plugin will process the data. Because of this RAM will be used for data that no one will actually ever handle (which can be a problem on devices with lower amounts of RAM).

When returning any Error in NPP_NewStream the browser will immediatley cancel the stream and stop caching the data keeping the memory footprint a lot lower. 

I chose NPP_NO_DATA, but actually any NPP_ERR_\* >= 0 would cause the Browser to cancel the stream.

Tested to work with WebKit, the behaviour is document in the NPAPI docs.
