### PR TITLE
try to avert issues like FB-182

### DIFF
--- a/gen_templates/FBControl.htm
+++ b/gen_templates/FBControl.htm
@@ -17,10 +17,10 @@
 
         function addEvent(obj, name, func)
         {
-            if (window.addEventListener) {
-                obj.addEventListener(name, func, false); 
-            } else {
+            if (obj.attachEvent) {
                 obj.attachEvent("on"+name, func);
+            } else {
+                obj.addEventListener(name, func, false); 
             }
         }
         


### PR DESCRIPTION
IE9 (in some modes) adds support for addEventListener, but Firebreath
requires events to be attached via attachEvent - so check for that
method first.
