### PR TITLE
added FBVLC::getVParam, same as PluginCore::getParam but for variant datatype.

### DIFF
--- a/src/PluginCore/PluginCore.cpp
+++ b/src/PluginCore/PluginCore.cpp
@@ -95,6 +95,15 @@ boost::optional<std::string> PluginCore::getParam(const std::string& key) {
     return rval;
 }
 
+boost::optional<FB::variant> FBVLC::getVParam(const std::string& key)
+{
+    boost::optional<FB::variant> rval;
+    FB::VariantMap::const_iterator fnd = m_params.find(key.c_str());
+    if (fnd != m_params.end())
+        rval.reset(fnd->second);
+    return rval;
+}
+
 // If you override this, you probably want to call it again, since this is what calls back into the page
 // to indicate that we're done.
 bool PluginCore::setReady()

--- a/src/PluginCore/PluginCore.h
+++ b/src/PluginCore/PluginCore.h
@@ -319,6 +319,7 @@ namespace FB {
         virtual void setParams(const FB::VariantMap& inParams);
         
         virtual boost::optional<std::string> getParam(const std::string& key);
+        virtual boost::optional<FB::variant> getVParam(const std::string& key);
 
     protected:
         /// The BrowserHost object for the current session


### PR DESCRIPTION
Sometimes it's useful...
