### PR TITLE
fix crash with FOLDERID_LocalAppDataLow not found

### DIFF
--- a/src/PluginCore/Win/SystemHelpersWin.cpp
+++ b/src/PluginCore/Win/SystemHelpersWin.cpp
@@ -24,7 +24,8 @@ typedef GUID KNOWNFOLDERID;
 
 #ifndef DEFINE_KNOWN_FOLDER
 #define DEFINE_KNOWN_FOLDER(name, l, w1, w2, b1, b2, b3, b4, b5, b6, b7, b8) \
-        EXTERN_C static const GUID name
+        EXTERN_C const GUID DECLSPEC_SELECTANY name \
+                = { l, w1, w2, { b1, b2,  b3,  b4,  b5,  b6,  b7,  b8 } }
 DEFINE_KNOWN_FOLDER(FOLDERID_LocalAppDataLow,     0xA520A1A4, 0x1780, 0x4FF6, 0xBD, 0x18, 0x16, 0x73, 0x43, 0xC5, 0xAF, 0x16);
 #undef DEFINE_KNOWN_FOLDER
 #endif


### PR DESCRIPTION
The macro DEFINE_KNOWN_FOLDER was copied from <KnownFolder.h>, it will link FOLDERID_LocalAppDataLow to an external dll.
but for some system(to me, Windows 7, Chinese Edition), the symbol can't be found at runtime, so FOLDERID_LocalAppDataLow becomes GUID_NULL, and at line 52, it will fail with crash.

Really strange.

Let's inspect <KnownFolder.h> again, there are two styles of DEFINE_KNOWN_FOLDER:

``` cpp
#ifdef INITGUID
#define DEFINE_KNOWN_FOLDER(name, l, w1, w2, b1, b2, b3, b4, b5, b6, b7, b8) \
        EXTERN_C const GUID DECLSPEC_SELECTANY name \
                = { l, w1, w2, { b1, b2,  b3,  b4,  b5,  b6,  b7,  b8 } }
#else
#define DEFINE_KNOWN_FOLDER(name, l, w1, w2, b1, b2, b3, b4, b5, b6, b7, b8) \
        EXTERN_C const GUID name
#endif // INITGUID
```

Shall we use the first one without `extern`?
