### PR TITLE
Add template for converting container and dictionary to VariantList and VariantMap

### DIFF
--- a/src/ScriptingCore/JSObject.h
+++ b/src/ScriptingCore/JSObject.h
@@ -18,6 +18,8 @@ Copyright 2009 Richard Bateman, Firebreath development team
 
 #include "JSAPI.h"
 #include "BrowserHost.h"
+#include "variant_list.h"
+#include "variant_map.h"
 #include <iterator>
 
 namespace FB
@@ -220,6 +222,41 @@ namespace FB
             else
                 return variant(FB::FBNull());
         }
+
+            template<class Cont>
+            typename boost::enable_if<
+                boost::mpl::and_<
+                    FB::meta::is_non_assoc_container<Cont>,
+                    boost::mpl::not_<
+                        boost::mpl::or_<
+                               boost::mpl::or_<
+                                   boost::is_same<std::vector<variant>, Cont>,
+                                   boost::is_same<std::map<std::string, variant>, Cont>
+                                >,
+                            boost::mpl::or_<
+                                   boost::is_same<std::wstring, Cont>,
+                                   boost::is_same<std::string, Cont>
+                                >
+                            >
+                    >
+                >
+             ,variant>::type
+             make_variant(const Cont& var) {
+            return make_variant_list(var);
+        }
+
+            template<class Dict>
+            typename boost::enable_if<
+                boost::mpl::and_<
+                    FB::meta::is_pair_assoc_container<Dict>,
+                    boost::mpl::not_<
+                            boost::is_same<std::map<std::string, variant>, Dict>
+                    >
+                >
+             ,variant>::type
+             make_variant(const Dict& var) {
+                      return make_variant_map(var);
+             }
 
         // Convert out
         template<class T>

--- a/src/ScriptingCore/variant_conversions.h
+++ b/src/ScriptingCore/variant_conversions.h
@@ -35,6 +35,37 @@ namespace FB {
             template <class T>
             typename boost::enable_if<boost::is_base_of<FB::JSObject, T>,variant>::type
             make_variant(const boost::shared_ptr<T>& ptr);
+
+            template<class Cont>
+            typename boost::enable_if<
+                boost::mpl::and_<
+                    FB::meta::is_non_assoc_container<Cont>,
+                    boost::mpl::not_<
+                        boost::mpl::or_<
+                               boost::mpl::or_<
+                                   boost::is_same<std::vector<variant>, Cont>,
+                                   boost::is_same<std::map<std::string, variant>, Cont>
+                                >,
+                            boost::mpl::or_<
+                                   boost::is_same<std::wstring, Cont>,
+                                   boost::is_same<std::string, Cont>
+                                >
+                            >
+                    >
+                >
+             ,variant>::type
+            make_variant(const Cont& var);
+            
+            template<class Dict>
+            typename boost::enable_if<
+                boost::mpl::and_<
+                    FB::meta::is_pair_assoc_container<Dict>,
+                    boost::mpl::not_<
+                            boost::is_same<std::map<std::string, variant>, Dict>
+                    >
+                >
+             ,variant>::type
+            make_variant(const Dict& var);
             
             template<class T>
             typename boost::enable_if<boost::is_base_of<FB::JSAPI, T>, boost::shared_ptr<T> >::type

--- a/src/ScriptingCore/variant_map.h
+++ b/src/ScriptingCore/variant_map.h
@@ -17,6 +17,7 @@ Copyright 2009 Georg Fritzsche, Firebreath development team
 #define H_VARIANT_MAP
 
 #include "APITypes.h"
+#include <iterator>
 
 namespace FB
 {
@@ -31,6 +32,47 @@ namespace FB
 
     ///////////////////////////////////
     // declarations
+
+    /// @brief Create a FB::VariantMap from any STL-style dictionary (i.e. exposes begin() and end())
+    /// @param cont A STL-style container.
+    /// @return A FB::VariantMap constructed from the cont.
+    template<typename Dict>
+    inline FB::VariantMap make_variant_map(const Dict& dict);
+    /// @brief Create a FB::VariantMap from the range [begin, end).
+    /// @param begin the start of the range
+    /// @param end the end of the range
+    /// @return A FB::VariantMap containing variants constructed from the contents of the range.
+    template<class InputIterator>
+    inline FB::VariantMap make_variant_map(InputIterator begin, InputIterator end);
+    /// @brief Fill a FB::VariantMap with the contents of the range [begin, end). 
+    /// @param begin the start of the range
+    /// @param end the end of the range
+    /// @param result An iterator to the begin of a VariantMap range big enough to hold last-first values.
+    template<class InputIterator>
+    inline void make_variant_map(InputIterator begin, InputIterator end, FB::VariantMap::iterator result);
+
+    /// @brief Convert a FB::VariantMap to STL-style dictionary (i.e. supports value_type and insert-iterators).
+    /// @return A Cont with the converted contents of the FB::VariantList.
+    template<class Dict>
+    inline Dict convert_variant_map(const FB::VariantMap& v);
+    /// @brief Fill to with the contents of from, converted to Cont::value_type.
+    /// @param from The input.
+    /// @param to The container to store the converted values in.
+    template<class Dict>
+    inline void convert_variant_map(const FB::VariantMap& from, Dict& to);
+    /// @brief Convert a range of FB::VariantMap to STL-style dictionary (i.e. supports value_type and insert-iterators).
+    /// @return A Cont with the converted contents of the FB::VariantMap range.
+    template<class Dict>
+    inline Dict convert_variant_map(FB::VariantMap::const_iterator begin,
+                              FB::VariantMap::const_iterator end);
+    /// @brief Fills the range [result, result+(end-begin)) with the contents of the range [begin,end), converted to To
+    /// @param begin the start of the range
+    /// @param end the end of the range
+    /// @param result Out parameter, shall be an output iterator.
+    template<typename To, class OutputIterator>
+    inline void convert_variant_map(FB::VariantMap::const_iterator begin,
+                              FB::VariantMap::const_iterator end,
+                              OutputIterator result);
 
     /// @brief Allows convenient creation of an FB::VariantMap.
     /// @return A helper type that overloads operator() for insertion and is convertible to FB::VariantMap.
@@ -99,6 +141,66 @@ namespace FB
     variant_map_of()
     {
         return std::map<T, FB::variant>();
+    }
+
+
+    template<class InputIterator>
+    inline void make_variant_map(InputIterator begin, 
+                           InputIterator end, 
+                           FB::VariantMap::iterator result)
+    {
+        while(begin != end)
+            *result++ = *begin++;
+    }
+
+    template<class InputIterator>
+    inline FB::VariantMap make_variant_map(InputIterator begin, InputIterator end)
+    {
+        FB::VariantMap result(end-begin);
+        std::copy(begin, end, result.begin());
+        return result;
+    }
+
+    template<class Dict>
+    inline FB::VariantMap make_variant_map(const Dict& d)
+    {
+        FB::VariantMap result;
+        std::copy(d.begin(), d.end(), std::inserter(result, result.begin()));
+        return result;
+    }
+
+    template<typename To, class OutputIterator>
+    inline void convert_variant_map(FB::VariantMap::const_iterator begin,
+                              FB::VariantMap::const_iterator end,
+                              OutputIterator result)
+    {
+        while(begin != end){
+            FB::VariantMap::const_iterator it = begin++;
+            *result++ = To(it->first, it->second.convert_cast<typename To::second_type>());
+        }
+    }
+
+    template<class Dict>
+    inline Dict convert_variant_map(FB::VariantMap::const_iterator begin,
+                              FB::VariantMap::const_iterator end)
+    {
+        Dict to;
+        convert_variant_map<typename Dict::value_type>(begin, end, std::inserter(to, to.begin()));
+        return to;
+    }
+
+    template<class Dict>
+    inline Dict convert_variant_map(const FB::VariantMap& from)
+    {
+        Dict to;
+        convert_variant_map<typename Dict::value_type>(from.begin(), from.end(), std::inserter(to, to.begin()));
+        return to;
+    }
+
+    template<class Dict>
+    inline void convert_variant_map(const FB::VariantMap& from, Dict& to)
+    {
+        convert_variant_map<typename Dict::value_type>(from.begin(), from.end(), std::inserter(to, to.begin()));
     }
 }
 

--- a/tests/ScriptingCoreTest/variant_map_test.h
+++ b/tests/ScriptingCoreTest/variant_map_test.h
@@ -23,12 +23,15 @@ TEST(VariantMapTest)
     PRINT_TESTNAME;
 
     using boost::assign::list_of;
-    
-    {
-        typedef std::map<std::string, FB::variant> VariantMap;
-        typedef std::pair<VariantMap::key_type, VariantMap::mapped_type> MapPair;
-        typedef std::vector<std::string> StringVec;
+    using boost::assign::map_list_of;
+    using FB::convert_variant_map;
+    using FB::make_variant_map;
+
+    typedef std::map<std::string, FB::variant> VariantMap;
+    typedef std::pair<VariantMap::key_type, VariantMap::mapped_type> MapPair;
+    typedef std::vector<std::string> StringVec;
         
+    {
         StringVec names = list_of("a")("b")("c")("d")("e");
         VariantMap values = FB::variant_map_of<std::string>("a","a")("b","b")("c","c")("d","d")("e","e");
 
@@ -40,6 +43,26 @@ TEST(VariantMapTest)
             CHECK(*itn == itv->first);
             CHECK(*itn == itv->second.convert_cast<std::string>());
         }
+    }
+    {
+        StringVec names = list_of("a")("b")("c")("d")("e");
+        std::map<std::string, std::string> sm = map_list_of("a","a")("b","b")("c","c")("d","d")("e","e");
+        FB::VariantMap vm = make_variant_map(sm);
+
+        StringVec::const_iterator  itn = names.begin();
+        VariantMap::const_iterator itv = vm.begin();
+
+        for( ; itn!=names.end() && itv!=vm.end(); ++itn, ++itv)
+        {
+            CHECK(*itn == itv->first);
+            CHECK(*itn == itv->second.convert_cast<std::string>());
+        }
+
+        CHECK((sm == convert_variant_map< std::map<std::string, std::string> >(vm)));
+
+        std::map<std::string, std::string> sm2;
+        convert_variant_map(vm, sm2);
+        CHECK(sm == sm2);
     }
 }
 


### PR DESCRIPTION
We talk about that on IRC.

It allows to register function using std::vector/std::map (all iterable container) as return value.
It's not optimal but its allow to not add/change existing functions.
