### PR TITLE
Fix 'not all control paths return a value' warning.

### DIFF
--- a/src/ActiveXCore/AXDOM/Element.cpp
+++ b/src/ActiveXCore/AXDOM/Element.cpp
@@ -64,7 +64,8 @@ std::string FB::ActiveX::AXDOM::Element::getStringAttribute( const std::string& 
     HRESULT hr = S_OK;
     if (elem) {
         hr = elem->getAttribute(CComBSTR(FB::utf8_to_wstring(attr).c_str()), 0, &var);
-        
+        USES_CONVERSION;
+        return std::string(W2CA(var.bstrVal));
     } else {
         return getProperty<std::string>(attr);
     }


### PR DESCRIPTION
Hi Richard,

Here's a quick windows build fix.

WARNINGS:

1) My ATL/COM skills & past exposure are, well... non-existent.
2) I did not run this code. I only made the compiler happy.

Cheers,
Nicolas
