### PR TITLE
Fix broken firebreath-boost install

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -293,7 +293,7 @@ function (fb_check_boost)
                 #file(REMOVE ${CMAKE_CURRENT_BINARY_DIR}/boost.tar.gz)
                 message("Installing firebreath-boost...")
                 file (GLOB _BOOST_FILES
-                    ${FB_BOOST_SOURCE_DIR}/firebreath-firebreath-boost*/*)
+                    ${FB_BOOST_SOURCE_DIR}/firebreath-firebreath-boost/*)
                 foreach (_CUR_FILE ${_BOOST_FILES})
                     get_filename_component (_CUR_FILENAME ${_CUR_FILE} NAME)
                     file(RENAME ${_CUR_FILE} ${FB_BOOST_SOURCE_DIR}/${_CUR_FILENAME})


### PR DESCRIPTION
The glob pattern was causing multiple slashes in the path being used to install the firebreath-boost files, which resulted in "No such file or directory" errors. (Possibly only on Windows.)

Here is the relevant log data from the console when running prep2012.cmd from the command line:

```
Using 7-zip to extract the archive
Installing firebreath-boost...
CMake Error at cmake/common.cmake:299 (file):
  file RENAME failed to rename

    C:/Users/stevenlybeck/Documents/projects/BrowserPlugin/firebreath/src/3rdParty/boost/firebreath-firebreath-boost-4bc2ed3//libs

  to

    C:/Users/stevenlybeck/Documents/projects/BrowserPlugin/firebreath/src/3rdParty/boost/libs

  because: No such file or directory
```
