### PR TITLE
Invalid UTF chars in strings

### DIFF
--- a/src/3rdParty/utf8/utf8/checked.h
+++ b/src/3rdParty/utf8/utf8/checked.h
@@ -69,6 +69,32 @@ namespace utf8
 
     /// The library API - functions intended to be called by the users
 
+    template <typename octet_iterator>
+    octet_iterator append(uint32_t cp, octet_iterator result)
+    {
+        if (!internal::is_code_point_valid(cp))
+            throw invalid_code_point(cp);
+
+        if (cp < 0x80)                        // one octet
+            *(result++) = static_cast<uint8_t>(cp);
+        else if (cp < 0x800) {                // two octets
+            *(result++) = static_cast<uint8_t>((cp >> 6)            | 0xc0);
+            *(result++) = static_cast<uint8_t>((cp & 0x3f)          | 0x80);
+        }
+        else if (cp < 0x10000) {              // three octets
+            *(result++) = static_cast<uint8_t>((cp >> 12)           | 0xe0);
+            *(result++) = static_cast<uint8_t>(((cp >> 6) & 0x3f)   | 0x80);
+            *(result++) = static_cast<uint8_t>((cp & 0x3f)          | 0x80);
+        }
+        else {      // four octets
+            *(result++) = static_cast<uint8_t>((cp >> 18)           | 0xf0);
+            *(result++) = static_cast<uint8_t>(((cp >> 12) & 0x3f)  | 0x80);
+            *(result++) = static_cast<uint8_t>(((cp >> 6) & 0x3f)   | 0x80);
+            *(result++) = static_cast<uint8_t>((cp & 0x3f)          | 0x80);
+        }
+        return result;
+    }
+	
     template <typename octet_iterator, typename output_iterator>
     output_iterator replace_invalid(octet_iterator start, octet_iterator end, output_iterator out, uint32_t replacement)
     {
@@ -105,32 +131,6 @@ namespace utf8
     {
         static const uint32_t replacement_marker = internal::mask16(0xfffd);
         return replace_invalid(start, end, out, replacement_marker);
-    }
-
-    template <typename octet_iterator>
-    octet_iterator append(uint32_t cp, octet_iterator result)
-    {
-        if (!internal::is_code_point_valid(cp))
-            throw invalid_code_point(cp);
-
-        if (cp < 0x80)                        // one octet
-            *(result++) = static_cast<uint8_t>(cp);
-        else if (cp < 0x800) {                // two octets
-            *(result++) = static_cast<uint8_t>((cp >> 6)            | 0xc0);
-            *(result++) = static_cast<uint8_t>((cp & 0x3f)          | 0x80);
-        }
-        else if (cp < 0x10000) {              // three octets
-            *(result++) = static_cast<uint8_t>((cp >> 12)           | 0xe0);
-            *(result++) = static_cast<uint8_t>(((cp >> 6) & 0x3f)   | 0x80);
-            *(result++) = static_cast<uint8_t>((cp & 0x3f)          | 0x80);
-        }
-        else {      // four octets
-            *(result++) = static_cast<uint8_t>((cp >> 18)           | 0xf0);
-            *(result++) = static_cast<uint8_t>(((cp >> 12) & 0x3f)  | 0x80);
-            *(result++) = static_cast<uint8_t>(((cp >> 6) & 0x3f)   | 0x80);
-            *(result++) = static_cast<uint8_t>((cp & 0x3f)          | 0x80);
-        }
-        return result;
     }
 
     template <typename octet_iterator>

--- a/src/ScriptingCore/utf8_tools.cpp
+++ b/src/ScriptingCore/utf8_tools.cpp
@@ -36,10 +36,12 @@ namespace FB {
 
     std::string wstring_to_utf8(const std::wstring& src) {
         std::string out_str;
+        std::wstring in_str;
+        utf8::replace_invalid(src.begin(), src.end(), std::back_inserter(in_str));
 #ifdef _WIN32
-        utf8::utf16to8(src.begin(), src.end(), std::back_inserter(out_str));
+        utf8::utf16to8(in_str.begin(), in_str.end(), std::back_inserter(out_str));
 #else
-        utf8::utf32to8(src.begin(), src.end(), std::back_inserter(out_str));
+        utf8::utf32to8(in_str.begin(), in_str.end(), std::back_inserter(out_str));
 #endif
         return out_str;
     }
@@ -47,10 +49,12 @@ namespace FB {
 
     std::wstring utf8_to_wstring(const std::string& src) {
         std::wstring out_str;
+        std::string in_str;
+        utf8::replace_invalid(src.begin(), src.end(), std::back_inserter(in_str));
 #ifdef _WIN32
-        utf8::utf8to16(src.begin(), src.end(), std::back_inserter(out_str));
+        utf8::utf8to16(in_str.begin(), in_str.end(), std::back_inserter(out_str));
 #else
-        utf8::utf8to32(src.begin(), src.end(), std::back_inserter(out_str));
+        utf8::utf8to32(in_str.begin(), in_str.end(), std::back_inserter(out_str));
 #endif
         return out_str;
     }


### PR DESCRIPTION
In order to avoid exception when converting utf8 to utf16/32 (and otherwise) we replace invalid characters by a replacement character.

There is many issues:

-The utf8::replace_invalid in wstring_to_utf8 is not correct. the library doesn't provide a way to replace invalid character in utf-16. Myabe adding one can be usefull.

-replace_invalid can throw an exception NOT_ENOUGH_ROOM. It seems that happen when we reach the end of the string before a complete utf8 char. I don't know why throw an exception. Maybe replace the incomplet utf char by the replacement character is enough.

-The 49fb1f1 commit can be replace by updating the lib(the change is already made). If we don't declare "append" before, clang is not happy.