### PR TITLE
Use Windows Driver Kit 8 in Windows 8

### DIFF
--- a/cmake/Win.cmake
+++ b/cmake/Win.cmake
@@ -164,8 +164,10 @@ macro(firebreath_sign_file PROJNAME _FILENAME PFXFILE PASSFILE TIMESTAMP_URL)
         if (EXISTS ${PFXFILE})
             message("-- ${_FILENAME} will be signed with ${PFXFILE}")
             GET_FILENAME_COMPONENT(WINSDK_DIR "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Microsoft SDKs\\Windows;CurrentInstallFolder]" REALPATH CACHE)
+            GET_FILENAME_COMPONENT(WINKIT_DIR "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots;KitsRoot]" REALPATH CACHE)
             find_program(SIGNTOOL signtool
                 PATHS
+                ${WINKIT_DIR}/bin/x64
                 ${WINSDK_DIR}/bin
                 )
             if (SIGNTOOL)


### PR DESCRIPTION
Hi Richard, I made a small change so I can use the signtool included in Windows Driver Kit 8. I'm running Windows 8 with Visual Studio Express 2012 and with just this change I'm able to use the latest signtool. I just added the location for the new directory leaving the old ones so people with old signtool or configuration should be ok without any changes.
