### PR TITLE
Rename os to opsys in PluginCore::setPlatform()

### DIFF
--- a/src/PluginCore/PluginCore.cpp
+++ b/src/PluginCore/PluginCore.cpp
@@ -33,11 +33,11 @@ volatile int PluginCore::ActivePluginCount = 0;
 
 std::string PluginCore::OS;
 std::string PluginCore::Browser;
-void PluginCore::setPlatform(const std::string& os, const std::string& browser)
+void PluginCore::setPlatform(const std::string& opsys, const std::string& browser)
 {
-    PluginCore::OS = os;
+    PluginCore::OS = opsys;
     PluginCore::Browser = browser;
-    FBLOG_INFO("PluginCore", "os: " << os << "; browser: " << browser);
+    FBLOG_INFO("PluginCore", "os: " << opsys << "; browser: " << browser);
 }
 
 /***************************\


### PR DESCRIPTION
`os` is used as function argument name in `setPlatform()` and also in the `FBLOG_LOG_BODY` macro as local variable name (in the `do { ... } while(0)` scope). The latter `os` masks the outer scope function argument `os` in `FBLOG_INFO` so that the macro becomes invalid. This (rightly) confuses VS 2013.
