### PR TITLE
Stable Event IDs for Safari

### DIFF
--- a/src/ActiveXCore/IDispatchAPI.h
+++ b/src/ActiveXCore/IDispatchAPI.h
@@ -37,7 +37,7 @@ namespace FB { namespace ActiveX {
         static boost::shared_ptr<IDispatchAPI> create(IDispatch *, const ActiveXBrowserHostPtr&);
         virtual ~IDispatchAPI(void);
 
-        void *getEventId() const
+        void *getEventId()
         {
             IDispatchSRef sref(m_obj.lock());
             if (sref) return (void*)sref->getPtr();

--- a/src/NpapiCore/NPObjectAPI.h
+++ b/src/NpapiCore/NPObjectAPI.h
@@ -16,6 +16,7 @@ Copyright 2009 Richard Bateman, Firebreath development team
 #ifndef H_NPOBJECTAPI
 #define H_NPOBJECTAPI
 
+#include <boost/thread/mutex.hpp>
 #include "NpapiTypes.h"
 #include "npruntime.h"
 #include "JSAPI.h"
@@ -36,7 +37,7 @@ namespace FB { namespace Npapi {
         NPObjectAPI(NPObject *, const NpapiBrowserHostPtr&);
         virtual ~NPObjectAPI(void);
 
-        void *getEventId() const { return (void*)obj; }
+        void *getEventId();
         void *getEventContext() const {
             if (!m_browser.expired())
                 return getHost()->getContextID();
@@ -68,6 +69,12 @@ namespace FB { namespace Npapi {
         NPObject *obj;
         bool is_JSAPI;
         FB::JSAPIWeakPtr inner;
+
+        static const std::string eventIdProperty;
+        void *m_eventId;
+
+        static unsigned int m_lastEventId;
+        static boost::mutex m_lastEventId_mutex;
 
     public:
         bool HasMethod(const std::string& methodName) const;

--- a/src/ScriptingCore/JSAPIImpl.cpp
+++ b/src/ScriptingCore/JSAPIImpl.cpp
@@ -251,11 +251,12 @@ void JSAPIImpl::registerEventMethod(const std::string& name, JSObjectPtr &event)
     if (!event)
         throw invalid_arguments();
 
+    void *eventId = event->getEventId(); // Need to call this to be sure we have a real event id.
     boost::recursive_mutex::scoped_lock _l(m_eventMutex);
     std::pair<EventMultiMap::iterator, EventMultiMap::iterator> range = m_eventMap[event->getEventContext()].equal_range(name);
 
     for (EventMultiMap::iterator it = range.first; it != range.second; ++it) {
-        if (it->second->getEventId() == event->getEventId()) {
+        if (it->second->getEventId() == eventId) {
             return; // Already registered
         }
     }
@@ -268,11 +269,12 @@ void JSAPIImpl::unregisterEventMethod(const std::string& name, JSObjectPtr &even
     if (!event)
         throw invalid_arguments();
 
+    void *eventId = event->getEventId(); // Need to call this to be sure we have a real event id.
     boost::recursive_mutex::scoped_lock _l(m_eventMutex);
     std::pair<EventMultiMap::iterator, EventMultiMap::iterator> range = m_eventMap[event->getEventContext()].equal_range(name);
 
     for (EventMultiMap::iterator it = range.first; it != range.second; ++it) {
-        if (it->second->getEventId() == event->getEventId()) {
+        if (it->second->getEventId() == eventId) {
             m_eventMap[event->getEventContext()].erase(it);
             return;
         }

--- a/src/ScriptingCore/JSObject.h
+++ b/src/ScriptingCore/JSObject.h
@@ -65,7 +65,7 @@ namespace FB
         ////////////////////////////////////////////////////////////////////////////////////////////////////
         virtual ~JSObject() {}
 
-        virtual void *getEventId() const { return NULL; }
+        virtual void *getEventId() { return NULL; }
         virtual void *getEventContext() const { return NULL; }
 
         virtual bool supportsOptimizedCalls() const { return false; }

--- a/src/WebKitCore/JSObjectRefAPI.h
+++ b/src/WebKitCore/JSObjectRefAPI.h
@@ -34,7 +34,7 @@ namespace FB { namespace WebKit {
         JSObjectRefAPI(JSObjectRef, const WebKitBrowserHostPtr&);
         virtual ~JSObjectRefAPI(void);
         
-        void *getEventId() const { return (void*)getJSObjectRef(); }
+        void *getEventId() { return (void*)getJSObjectRef(); }
         void *getEventContext() const {
             if (!m_browser.expired())
                 return getHost()->getContextID();


### PR DESCRIPTION
Safari rewraps a JavaScript object before passing it to FireBreath. This is problematic for {add,remove}EventListener because they rely on the pointer to the NPObject as a stable ID. This patch creates a new stable ID and stores it in the __fb_event_id property on the object. 

See http://jira.firebreath.org/browse/FIREBREATH-243.
