### PR TITLE
Add contents scale change event (handles NPNVcontentsScaleFactor).

### DIFF
--- a/src/PluginAuto/Mac/NpapiPluginMac.h
+++ b/src/PluginAuto/Mac/NpapiPluginMac.h
@@ -49,6 +49,7 @@ namespace FB { namespace Npapi {
         
     private:
         int16_t GetValue(NPPVariable variable, void* value);
+        NPError SetValue(NPNVariable variable, void* value);
     };
 
 }; }; // FB::Npapi

--- a/src/PluginAuto/Mac/NpapiPluginMac.mm
+++ b/src/PluginAuto/Mac/NpapiPluginMac.mm
@@ -29,6 +29,8 @@ Copyright 2009 PacketPass, Inc and the Firebreath development team
 
 #include "Mac/NpapiPluginMac.h"
 
+#include "PluginEvents/DrawingEvents.h"
+
 using namespace FB::Npapi;
 
 FB::Npapi::NpapiPluginPtr FB::Npapi::createNpapiPlugin(const FB::Npapi::NpapiBrowserHostPtr& host, const std::string& mimetype)
@@ -95,6 +97,19 @@ void NpapiPluginMac::init(NPMIMEType pluginType, int16_t argc, char* argn[], cha
             pluginWin->setShowDrawingModel(true);
     }
 }
+NPError NpapiPluginMac::SetValue(NPNVariable variable, void *value)
+{
+	if (variable == NPNVcontentsScaleFactor) {
+		double contentsScaleFactor = *(double *)value;
+		ContentsScaleFactorChangedEvent ev(contentsScaleFactor);
+		// Ignore the return value (whether the event was handled) since we don't have
+  		// any fallback handlers anyway.
+		pluginWin->SendEvent(&ev);
+	}
+
+    return NPERR_NO_ERROR;
+}
+
 
 NPError NpapiPluginMac::SetWindow(NPWindow* window) {
     NPError res = NPERR_NO_ERROR;

--- a/src/PluginCore/PluginEvents/DrawingEvents.h
+++ b/src/PluginCore/PluginEvents/DrawingEvents.h
@@ -111,6 +111,24 @@ namespace FB {
             bool m_hasFocus;
     };
 
+    ////////////////////////////////////////////////////////////////////////////////////////////////////
+    /// @class  Content scale factor change
+    ///
+    /// @brief  Fired when DPI settings change (e.g. when moving webbrowser window between Retina
+    ///         and non-Retina displays)
+    ////////////////////////////////////////////////////////////////////////////////////////////////////
+    class ContentsScaleFactorChangedEvent : public PluginEvent
+    {
+        public:
+            ContentsScaleFactorChangedEvent(double contentsScaleFactor)
+                : m_contentsScaleFactor(contentsScaleFactor) {}
+            virtual ~ContentsScaleFactorChangedEvent() { }
+
+            double contentsScaleFactor() { return m_contentsScaleFactor; }
+        protected:
+            double m_contentsScaleFactor;
+    };
+
 };
 
 #endif // H_FB_PLUGINEVENTS_DRAWINGEVENTS


### PR DESCRIPTION
This commit adds a new event, called ContentsScaleFactorChangedEvent, raised when browser notifies the plugin of dpi change.

I made this Mac only since this is most important for Retina displays (and that was the only system I was able to test my change).

Please let me know what you think, and especially if you wanted me to change any of it.

Thanks
Grzegorz Milos (gregor.milos@bromium.com)
