### PR TITLE
Add "nodeName" as a reserved property in JSAPIAuto

### DIFF
--- a/src/ScriptingCore/JSAPIAuto.cpp
+++ b/src/ScriptingCore/JSAPIAuto.cpp
@@ -71,6 +71,7 @@ void FB::JSAPIAuto::init( )
     setReserved("style");
     setReserved("id");
     setReserved("constructor");
+    setReserved("nodeName");
 }
 
 FB::JSAPIAuto::~JSAPIAuto()


### PR DESCRIPTION
This fixes an issue using a firebreath plugin with angular: "TypeError: Cannot read property 'nodeName' of undefined".

I tested it with Chrome, Firefox, and IE on Windows 7.

This was brought up on [stackoverflow](http://stackoverflow.com/questions/15351830/firebreath-object-in-angularjs) and in the [forum](https://groups.google.com/forum/#!topic/firebreath-dev/70xKyN4tox4).
