### PR TITLE
FIREBREATH-251 Patch

### DIFF
--- a/cmake/CommonPluginConfig.cmake
+++ b/cmake/CommonPluginConfig.cmake
@@ -70,9 +70,11 @@ string(REGEX REPLACE "\\.dll$" "" FBSTRING_PluginFileName "${FBSTRING_PluginFile
 if (FB_ATLREG_MACHINEWIDE)
     set(REGKEY_ROOT "HKLM")
     set(FB_WIX_INSTALL_LOCATION "ProgramFilesFolder")
+    set(FB_WIX_INSTALL_SCOPE "perMachine")
 else()
     set(REGKEY_ROOT "HKCU")
     set(FB_WIX_INSTALL_LOCATION "AppDataFolder")
+    set(FB_WIX_INSTALL_SCOPE "perUser")
 endif()
 
 set(FB_VERSION_SPLIT ${FBSTRING_PLUGIN_VERSION})

--- a/fbgen/src/Win/WiX/TemplateInstaller.wxs
+++ b/fbgen/src/Win/WiX/TemplateInstaller.wxs
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Id="*" Name="${FBSTRING_PluginName}" Language="1033" Version="${FBSTRING_PLUGIN_VERSION}" Manufacturer="${FBSTRING_CompanyName}" UpgradeCode="{${FBControl_WixUpgradeCode_GUID}}">
-        <Package InstallerVersion="200" Compressed="yes" Description="Installer for the ${FBSTRING_PluginName} plugin" InstallScope="perUser" />
+        <Package InstallerVersion="200" Compressed="yes" Description="Installer for the ${FBSTRING_PluginName} plugin" InstallScope="${FB_WIX_INSTALL_SCOPE}" />
         <Upgrade Id="{@{GUIDS_INSTUPGR}}">
             <UpgradeVersion
                 Property="OLD_VERSION_FOUND"


### PR DESCRIPTION
This patch fixes the issue mentioned in FB-251, allowing the proper Wix configuration for a per-machine installer. The change is small, an additional cmake variable being set, based on the status of FB_ATLREG_MACHINEWIDE, which is the used in then TemplateInstaller.wxs for project generation to allow for proper configuration of a machine-wide installer for windows.

See: http://jira.firebreath.org/browse/FIREBREATH-251
