### PR TITLE
Remove browser detection which broke on IE11

### DIFF
--- a/examples/FBTestPlugin/switcher.html
+++ b/examples/FBTestPlugin/switcher.html
@@ -10,7 +10,6 @@
             .hidden { display: none; }
             #delay { width: 100px; border: none; }
             #counters span { margin-right: 80px; font-size: 120pt; }
-            #browserVersion { font-size: 18pt; color: #336699; }
         </style>
         <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.5.1/jquery.min.js"></script>
         <script type="text/javascript">
@@ -19,9 +18,6 @@
                     // Make sure the newest version of the plugin will be found.
                     navigator.plugins.refresh(false);
                 }
-                var ua = $.browser;
-                var uaVersion = parseFloat(ua.version);
-                var browser = "";
                 var getUrlParameters = function() {
                     var map = {};
                     var parts = window.location.href.replace(/[?&]+([^=&]+)=([^&]*)/gi, function(m,key,value) {
@@ -33,23 +29,6 @@
                 var decode = function(str) {
                     return unescape(str.replace(/\+/g, " "));
                 };
-                if (ua.mozilla) {
-                    var r = RegExp(/(Firefox)\/([0-9.]+)/);
-                    var matches = navigator.userAgent.match(r);
-                    browser = matches[0].replace('/', ' ');
-                } else if (ua.webkit) {
-                    var chrome = RegExp(/Chrome\/([0-9.]+)/);
-                    var safari = RegExp(/Version\/([0-9.]+)/);
-                    if (navigator.userAgent.match(chrome)) {
-                        browser = "Chrome " + navigator.userAgent.match(chrome)[1];
-                    } else {
-                        browser = "Safari " + navigator.userAgent.match(safari)[1];
-                    }
-                } else if (ua.msie) {
-                    browser = "Internet Explorer " + ua.version;
-                } else {
-                    browser = "Unknown";
-                }
                 var autoSwitch = false;
                 var nextSrc = "srcA";
                 var updateDelay = function() {
@@ -62,7 +41,6 @@
                     $("#switch").trigger("click");
                 };
                 
-                $("#browserVersion").html(browser);
                 $("#pluginVersion").html("Plugin Version: " + plugin.pluginVersion);
                 $("#switch").click(function() {
                     var elem = $(this);
@@ -109,7 +87,6 @@
         </script>
     </head>
     <body>
-        <div id="browserVersion"></div>
         <iframe id="content" src=""></iframe>
         <p id="pluginVersion">
             <object type="application/x-fbtestplugin" id="plugin"></object>


### PR DESCRIPTION
maybe jquery is at fault? i'm not sure... but this browser detection isn't doing anything anyway, and has other dodgy code paths (eg line 46... what if it's webkit but not chrome or safari)
