### PR TITLE
Use OSX-SDK on Mac OSX 10.9

### DIFF
--- a/cmake/Mac.cmake
+++ b/cmake/Mac.cmake
@@ -88,7 +88,7 @@ MACRO(add_mac_plugin PROJECT_NAME PLIST_TEMPLATE STRINGS_TEMPLATE LOCALIZED_TEMP
     firebreath_find_commands()
     set(RC_COMPILER ${CMD_REZ})
     execute_process(COMMAND
-        ${RC_COMPILER} ${RCFILES} -useDF ${ARCHS} -arch x86_64 -o ${CMAKE_CURRENT_BINARY_DIR}/bundle/English.lproj/Localized.rsrc
+        ${RC_COMPILER} ${RCFILES} -useDF ${ARCHS} -arch x86_64 -o ${CMAKE_CURRENT_BINARY_DIR}/bundle/English.lproj/Localized.rsrc -is ${CMAKE_OSX_SYSROOT}
         )
 
     set_source_files_properties(


### PR DESCRIPTION
Building FireBreath on Mac OSX 10.9 currently fails because Apple removed all header files from public frameworks. Thus it requires the SDK to be set to find `CoreServices.r`.
