### PR TITLE
fixed clang++ and g++ c++11 "narrowing convertion" compilation errors

### DIFF
--- a/src/PluginAuto/Mac/PluginEventMacCarbon.cpp
+++ b/src/PluginAuto/Mac/PluginEventMacCarbon.cpp
@@ -56,7 +56,7 @@ Point PluginEventMacCarbon::GlobalToLocal(Point location) {
     if (pluginWindow) {
         WindowRef window = pluginWindow->getWindowRef();
         // Convert the global mouse location to window structure location.
-        HIPoint local = {location.h, location.v};
+        HIPoint local = {static_cast<float>(location.h), static_cast<float>(location.v)};
         HIPointConvert(&local, kHICoordSpaceScreenPixel, NULL, kHICoordSpaceWindow, window);
 
         // Get the location of the structure and port in the window.

--- a/src/PluginAuto/Mac/PluginEventMacCocoa.mm
+++ b/src/PluginAuto/Mac/PluginEventMacCocoa.mm
@@ -90,9 +90,11 @@ int16_t PluginEventMacCocoa::HandleEvent(void* event) {
     switch(evt->type) {
         case NPCocoaEventDrawRect: {
             if (window->getDrawingModel() == PluginWindowMac::DrawingModelCoreGraphics) {
-                FB::Rect clipRect = { evt->data.draw.y, evt->data.draw.x,
-                    evt->data.draw.y + evt->data.draw.height,
-                    evt->data.draw.x + evt->data.draw.width };
+                FB::Rect clipRect = {
+                    static_cast<int32_t>(evt->data.draw.y),
+                    static_cast<int32_t>(evt->data.draw.x),
+                    static_cast<int32_t>(evt->data.draw.y + evt->data.draw.height),
+                    static_cast<int32_t>(evt->data.draw.x + evt->data.draw.width) };
                 FB::Rect bounds = window->getWindowPosition();
                 CoreGraphicsDraw ev(evt->data.draw.context, bounds, clipRect);
                 return window->SendEvent(&ev);

--- a/src/PluginAuto/Mac/PluginWindowMac.mm
+++ b/src/PluginAuto/Mac/PluginWindowMac.mm
@@ -259,7 +259,8 @@ NPError PluginWindowMac::SetWindow(NPWindow* window) {
 }
 
 FB::Rect PluginWindowMac::getWindowPosition() const {
-    FB::Rect r = { m_y, m_x, m_y + m_height, m_x + m_width };
+    FB::Rect r = { static_cast<int32_t>(m_y), static_cast<int32_t>(m_x),
+                   static_cast<int32_t>(m_y + m_height), static_cast<int32_t>(m_x + m_width) };
     return r;
 }
 
@@ -316,7 +317,7 @@ void PluginWindowMac::StopAutoInvalidate() {
 
 void PluginWindowMac::InvalidateWindow() const {
     FBLOG_TRACE("PluginCore", "InvalidateWindow");
-    NPRect r = { 0, 0, m_height, m_width };
+    NPRect r = { 0, 0, static_cast<uint16_t>(m_height), static_cast<uint16_t>(m_width) };
     if (!m_npHost->isMainThread())
         m_npHost->ScheduleOnMainThread(m_npHost, boost::bind(&Npapi::NpapiBrowserHost::InvalidateRect2, m_npHost, r));
     else

--- a/src/PluginAuto/Mac/PluginWindowMacCG.cpp
+++ b/src/PluginAuto/Mac/PluginWindowMacCG.cpp
@@ -110,7 +110,8 @@ bool PluginWindowMacCG::SendEvent(PluginEvent* evt) {
         } else if (rval && evt->validType<MacEventCocoa>()) {
             FB::MacEventCocoa *event = evt->get<MacEventCocoa>();
             if (NPCocoaEventDrawRect == event->msg.type) {
-                FB::Rect bounds = { 0, 0, event->msg.data.draw.height, event->msg.data.draw.width };
+                FB::Rect bounds = { 0, 0, static_cast<int32_t>(event->msg.data.draw.height),
+                                    static_cast<int32_t>(event->msg.data.draw.width) };
                 DrawLabel(event->msg.data.draw.context, bounds);
             }
         } else if (rval && evt->validType<MacEventCarbon>() && rval) {


### PR DESCRIPTION
Just explicit casts where necessary for C++11.
