### PR TITLE
Fix detachEvent for IE11 on Windows 8+.

### DIFF
--- a/src/ActiveXCore/JSAPI_IDispatchEx.h
+++ b/src/ActiveXCore/JSAPI_IDispatchEx.h
@@ -87,7 +87,7 @@ namespace FB { namespace ActiveX {
             IDisp_DetachEvent(JSAPI_IDispatchExBase* ptr)
                 : FB::JSFunction(FB::JSAPIPtr(), "detachEvent", FB::SecurityScope_Public), obj(ptr) { }
             FB::variant exec(const std::vector<variant>& args) {
-                if (args.size() == 2) {
+                if (args.size() >=2 && args.size() <= 3) {
                     try {
                         std::string evtName = args[0].convert_cast<std::string>();
                         FB::JSObjectPtr method(args[1].convert_cast<FB::JSObjectPtr>());


### PR DESCRIPTION
This was fixed for attachEvent in 76dacf7.
