### PR TITLE
Fixes building ScriptingCore while using Visual Studio 2010 express

### DIFF
--- a/src/ScriptingCore/CMakeLists.txt
+++ b/src/ScriptingCore/CMakeLists.txt
@@ -28,6 +28,7 @@ include_directories(
     ${FB_PLUGINCORE_SOURCE_DIR}
     ${Boost_INCLUDE_DIRS}
     ${FB_CONFIG_DIR}
+    ${ATL_INCLUDE_DIR}
     )
 
 file (GLOB DOMTYPES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
ScriptingCore didn't have a proper include path to the ATL includes for me, adding this line fixes it.
