### PR TITLE
Fixes ActiveX control invalidateWindow rect

### DIFF
--- a/src/ActiveXCore/FBControl.h
+++ b/src/ActiveXCore/FBControl.h
@@ -252,10 +252,15 @@ namespace FB {
                 boost::shared_ptr<FB::ShareableReference<CFBControlX> > ref(boost::make_shared<FB::ShareableReference<CFBControlX> >(this));
                 m_host->ScheduleOnMainThread(ref, boost::bind(&CFBControlX::invalidateWindow, this, left, top, right, bottom));
             } else {
-            	FB::Rect pos = pluginWin->getWindowPosition();
-            	RECT r = { left+pos.left, top+pos.top, right+pos.left, bottom+pos.top };
-                if (m_spInPlaceSite)
-                    m_spInPlaceSite->InvalidateRect(&r, FALSE);
+                if (m_spInPlaceSite){
+					if(pluginWin){
+						FB::Rect pos = pluginWin->getWindowPosition();
+						RECT r = { left+pos.left, top+pos.top, right+pos.left, bottom+pos.top };
+						m_spInPlaceSite->InvalidateRect(&r, FALSE);
+					}else {
+						m_spInPlaceSite->InvalidateRect(NULL, FALSE);
+					}
+				}
             }
         }
 

--- a/src/ActiveXCore/FBControl.h
+++ b/src/ActiveXCore/FBControl.h
@@ -252,8 +252,10 @@ namespace FB {
                 boost::shared_ptr<FB::ShareableReference<CFBControlX> > ref(boost::make_shared<FB::ShareableReference<CFBControlX> >(this));
                 m_host->ScheduleOnMainThread(ref, boost::bind(&CFBControlX::invalidateWindow, this, left, top, right, bottom));
             } else {
+            	FB::Rect pos = pluginWin->getWindowPosition();
+            	RECT r = { left+pos.left, top+pos.top, right+pos.left, bottom+pos.top };
                 if (m_spInPlaceSite)
-                    m_spInPlaceSite->InvalidateRect(NULL, TRUE);
+                    m_spInPlaceSite->InvalidateRect(&r, FALSE);
             }
         }
 


### PR DESCRIPTION
I test on IE9/10/11, it is ok。My plugin is large than 1024x768, redraw every 100ms, the CPU usage is much less than before. And I think that the plugin should not erase background, it causes blinking!!