### PR TITLE
Fixed MSVC 2015 compilation errors for std::bad_cast throwing

### DIFF
--- a/src/ActiveXCore/AXDOM/Element.cpp
+++ b/src/ActiveXCore/AXDOM/Element.cpp
@@ -22,7 +22,7 @@ Element::Element(const FB::JSObjectPtr& element, IWebBrowser *web)
       m_axDisp(FB::ptr_cast<IDispatchAPI>(element)->getIDispatch()), m_webBrowser(web)
 {
     if (!m_axDisp)
-        throw std::bad_cast("This is not a valid object");
+        throw std::bad_cast();
 }
 
 Element::~Element()

--- a/src/ActiveXCore/AXDOM/Window.cpp
+++ b/src/ActiveXCore/AXDOM/Window.cpp
@@ -25,7 +25,7 @@ Window::Window(FB::JSObjectPtr obj, IWebBrowser2 *web)
     m_webBrowser(web), m_htmlWin(FB::ptr_cast<IDispatchAPI>(obj)->getIDispatch())
 {
     if (!m_htmlWin) {
-        throw new std::bad_cast("This is not a valid Window object");
+        throw new std::bad_cast();
     }
 }
 

--- a/src/ActiveXCore/IDispatchAPI.h
+++ b/src/ActiveXCore/IDispatchAPI.h
@@ -66,7 +66,7 @@ namespace FB { namespace ActiveX {
         ActiveXBrowserHostPtr getHost() const {
             ActiveXBrowserHostPtr ptr(m_browser.lock());
             if (!ptr) {
-                throw std::bad_cast("BrowserHost has shut down");
+                throw std::bad_cast();
             }
             return ptr;
         }

--- a/src/ActiveXCore/JSAPI_IDispatchEx.h
+++ b/src/ActiveXCore/JSAPI_IDispatchEx.h
@@ -119,7 +119,7 @@ namespace FB { namespace ActiveX {
         {
             FB::JSAPIPtr api(m_api.lock());
             if (!api)
-                throw std::bad_cast("Invalid object");
+                throw std::bad_cast();
             return api;
         }
         ActiveXBrowserHostPtr getHost() const {


### PR DESCRIPTION
Apparently MS compiler now follows the standard and doesn't specify a constructor taking string literals. Tested on MSVC 2015 RC.