### PR TITLE
FIREBREATH-274 Set reserved hasAttribute in JSAPIAuto

### DIFF
--- a/src/ScriptingCore/JSAPIAuto.cpp
+++ b/src/ScriptingCore/JSAPIAuto.cpp
@@ -72,6 +72,7 @@ void FB::JSAPIAuto::init( )
     setReserved("id");
     setReserved("constructor");
     setReserved("nodeName");
+    setReserved("hasAttribute");
 }
 
 FB::JSAPIAuto::~JSAPIAuto()


### PR DESCRIPTION
Reserving hasAttribute seems to be necessary to Safari 9 to be able to print the plugin in the JS console.

Ticket : http://jira.firebreath.org/browse/FIREBREATH-274