### PR TITLE
WyrmNativeMessagingHost crash fix

### DIFF
--- a/src/FireWyrm/WyrmColony.cpp
+++ b/src/FireWyrm/WyrmColony.cpp
@@ -100,6 +100,8 @@ FW_RESULT WyrmColony::ReleaseColony(FW_INST key) {
 
     if (!WyrmColony::ColonyInitialized) {
         getFactoryInstance()->globalPluginDeinitialize();
+        
+        localMethodMap.clear();
 
         // NOTE: If this assertion fails you have some sort of memory leak; BrowserHost objects
         // are reference counted, so you have a shared_ptr to your browserhost sometime. This


### PR DESCRIPTION
Added localFunctionMap.clear() on ReleaseColony before assert.
This allows to decrease shared_ptr references to BrowserHost owned by
localFunctionMap. No WrymColonies are initialized, so no need to keep this map.
Otherwise next assert fails if called withtin some seconds from last use.