### PR TITLE
fixed call setFSPath function

### DIFF
--- a/src/FireWyrm/WyrmSpawn.cpp
+++ b/src/FireWyrm/WyrmSpawn.cpp
@@ -26,6 +26,8 @@
 using namespace FB::FireWyrm;
 using FB::Promise;
 
+extern std::string g_dllPath;
+
 WyrmSpawn::WyrmSpawn(WyrmBrowserHostPtr host, std::string mimetype)
     : FB::BrowserPlugin(mimetype),
       m_fwHost(host),
@@ -35,6 +37,7 @@ WyrmSpawn::WyrmSpawn(WyrmBrowserHostPtr host, std::string mimetype)
     m_pluginName(getFactoryInstance()->getPluginName(mimetype))
 {
     pluginMain->SetHost(host);
+    setFSPath(g_dllPath);
 }
 
 WyrmSpawn::~WyrmSpawn(void)


### PR DESCRIPTION
you must call the function "setFSPath" to work properly plugins in Chrome