### PR TITLE
fixed cyrillic symbols usage in path

### DIFF
--- a/src/NativeMessageHost/Win/PluginLoaderWin.cpp
+++ b/src/NativeMessageHost/Win/PluginLoaderWin.cpp
@@ -85,7 +85,7 @@ PluginList PluginLoader::getPluginList() {
                     rc = RegQueryValueEx(hPluginItem, TEXT("Path"), NULL, NULL, (LPBYTE) lpData, &lpcbData); // Get the value of Path
                     if (rc == ERROR_SUCCESS)
                         plugin.path = utf8_conv.to_bytes(lpData);
-                    if (!exists(plugin.path)) {
+                    if (!exists(lpData)) {
                         // If the plugin file isn't there then don't display it as an option
                         continue;
                     }


### PR DESCRIPTION
path is first converted from WCHAR to UFT8 (plugin.path = utf8_conv.to_bytes(lpData);)
then this buffer is interpreted as ANSI string inside boost::filesystem::path contructor (exists(plugin.path)).
It is allright when english letters are used (UTF8 representation is equivalent to ANSI), but results in error, when cyrrilic or other symbols are met in path.
Passing WCHAR path solves this problem.