### PR TITLE
Close STDIN&STDOUT HANDLEs in NativeMessageHost on Windows

### DIFF
--- a/src/NativeMessageHost/HostMain.cpp
+++ b/src/NativeMessageHost/HostMain.cpp
@@ -20,6 +20,7 @@ Copyright 2015 GradeCam, Richard Bateman, and the
 #include <intrin.h>
 #include <io.h>
 #include <fcntl.h>
+#include <windows.h>
 #endif
 
 //#define DEBUG_BREAK
@@ -40,6 +41,8 @@ int main(int argc, char* argv[]) {
     _setmode(_fileno(stdout), _O_BINARY);
     _setmode(_fileno(stdin), _O_BINARY);
     _setmode(_fileno(stderr), _O_BINARY);
+    SetStdHandle(STD_INPUT_HANDLE, NULL);
+    SetStdHandle(STD_OUTPUT_HANDLE, NULL);
 #endif
 	log("Starting FireWyrm native message host");
     if (argv[1] != NULL) {


### PR DESCRIPTION
Not closing it may cause LoadLibrary hanging up (reproduced on Windows XP
when loading library with comctl32.dll dependency).

Applying fix similiar to https://codereview.chromium.org/194913004 by
weitaosu@chromium.org in chromium project.

"After the native messaging channel starts the native messaging reader
will keep doing blocking read operations on the input named pipe.
If any other thread tries to perform any operation on STDIN, it will also
block because the input named pipe is synchronous (non-overlapped).
It is pretty common for a DLL to query the device info (GetFileType) of
the STD* handles at startup. So any LoadLibrary request can potentially
be blocked. To prevent that from happening we close STDIN and STDOUT
handles as soon as we retrieve the corresponding file handles."