### PR TITLE
Minor changes to build FB 2.0 on different platforms with more recent tools

### DIFF
--- a/cmake/X11.cmake
+++ b/cmake/X11.cmake
@@ -27,7 +27,7 @@ set(BUILD_SHARED_LIBS YES)
 # This long line is ugly, but breaking it up to multiple lines will 
 # break on cmake 2.6. LD_FLAGS will get separated by semi-colon 
 # which is not gcc compatible
-set(NPAPI_LINK_FLAGS "-Wl,--discard-all -Wl,-Bsymbolic -Wl,-z,defs -Wl,--version-script=\"${FB_ROOT_DIR}/gen_templates/version_script.txt\"")
+set(NPAPI_LINK_FLAGS "-Wl,--discard-all -Wl,-Bsymbolic -Wl,-z,defs -Wl,--version-script=\"${FB_ROOT}/gen_templates/version_script.txt\"")
 
 MACRO(find_firebreath_x11_deps)
 

--- a/cmake/buildconfig.cmake
+++ b/cmake/buildconfig.cmake
@@ -86,7 +86,9 @@ if(UNIX)
         # In addition, Gecko SDK on Mac OS X needs XP_MACOSX
         set(gecko_defs "${gecko_defs} -DXP_MACOSX")
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DFB_MACOSX=1 -DUNICODE -D_UNICODE")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DFB_MACOSX=1 -DUNICODE -D_UNICODE")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -stdlib=libc++ -DFB_MACOSX=1 -DUNICODE -D_UNICODE")
+        set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++11")
+        set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
     endif()
 
     if(NOT APPLE)

--- a/prep2015.cmd
+++ b/prep2015.cmd
@@ -1,0 +1,7 @@
+@echo off & setlocal enableextensions enabledelayedexpansion
+
+set _FB_GEN="Visual Studio 14"
+
+call "%~d0%~p0\common.cmd" %*
+if %errorlevel% == 2 exit /b 1
+call "%~d0%~p0\winprep.cmd"

--- a/prep2015x64.cmd
+++ b/prep2015x64.cmd
@@ -1,0 +1,7 @@
+@echo off & setlocal enableextensions enabledelayedexpansion
+
+set _FB_GEN="Visual Studio 14 Win64"
+
+call "%~d0%~p0\common.cmd" %*
+if %errorlevel% == 2 exit /b 1
+call "%~d0%~p0\winprep.cmd"

--- a/prepmake.sh
+++ b/prepmake.sh
@@ -7,5 +7,5 @@ fi
 source ${0%/*}/common.sh "$@"
 
 pushd "$BUILDDIR"
-cmake -G "$GEN" -DFB_PROJECTS_DIR="${PROJDIR}" "$@" "${FB_ROOT}"
+cmake -G "$GEN" -DFB_ROOT="${FB_ROOT}" "$@" "${PROJDIR}"
 popd

--- a/src/NativeMessageHost/CMakeLists.txt
+++ b/src/NativeMessageHost/CMakeLists.txt
@@ -93,7 +93,6 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
 
 if (FIREBREATH)
     link_boost_library(${PROJECT_NAME} filesystem)
-    link_boost_library(${PROJECT_NAME} regex)
 endif()
 
 if (UNIX AND NOT CMAKE_SYSTEM_NAME MATCHES "BSD")

--- a/src/NativeMessageHost/CMakeLists.txt
+++ b/src/NativeMessageHost/CMakeLists.txt
@@ -27,6 +27,7 @@ if (FIREBREATH)
 endif()
 
 include_directories(
+    ${FB_GECKOSDK_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${FB_CONFIG_DIR}
     ${Boost_INCLUDE_DIRS}
@@ -92,6 +93,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
 
 if (FIREBREATH)
     link_boost_library(${PROJECT_NAME} filesystem)
+    link_boost_library(${PROJECT_NAME} regex)
 endif()
 
 if (UNIX AND NOT CMAKE_SYSTEM_NAME MATCHES "BSD")

--- a/src/NativeMessageHost/X11/PluginLoaderLin.cpp
+++ b/src/NativeMessageHost/X11/PluginLoaderLin.cpp
@@ -14,7 +14,7 @@ Copyright 2015 GradeCam, Richard Bateman, and the
 \**********************************************************/
 
 #include <boost/filesystem.hpp>
-#include <boost/regex.hpp>
+#include <regex>
 #include <dlfcn.h>
 #include <locale>
 #include "npapi.h"
@@ -44,9 +44,8 @@ PluginList PluginLoader::getPluginList() {
     std::string user_plugin_path = home + "/.mozilla/plugins";
     std::string system_plugin_path = "/usr/lib/mozilla/plugins";
     std::vector<std::string> plugin_paths = {user_plugin_path, system_plugin_path};
-    boost::regex mime_regex("(\\w*?[/][\\w\\-\\.]+?)(?:[;\\:])|$");
+    std::regex mime_regex("(\\w*?[/][\\w\\-\\.]+?)(?:[;\\:])|$");
     void *dlo_handle;
-    boost::match_results<std::string::const_iterator> char_matches;
 
     func_ptr NP_GetMIMEDescription;
     func_ptr NP_GetPluginVersion;
@@ -89,7 +88,7 @@ PluginList PluginLoader::getPluginList() {
                         NP_GetMIMEDescription = (func_ptr) dlsym(dlo_handle, "NP_GetMIMEDescription");
                         if (!(err = dlerror())) {
                             mime_desc = NP_GetMIMEDescription();
-                            boost::sregex_token_iterator iter(mime_desc.begin(), mime_desc.end(), mime_regex, 1),
+                            std::sregex_token_iterator iter(mime_desc.begin(), mime_desc.end(), mime_regex, 1),
                                                          end;
                             for(; iter != end; ++iter) {
                                 if (find(plugin.mime_types.begin(), plugin.mime_types.end(), *iter) == plugin.mime_types.end()) {

--- a/src/PluginAuto/log4cplus/log4cplus.cpp
+++ b/src/PluginAuto/log4cplus/log4cplus.cpp
@@ -115,34 +115,40 @@ static log4cplus::LogLevel translate_logLevel(FB::Log::LogLevel ll){
     }
 }
 
+
+std::string getFilename(const std::string& str)
+{
+	std::size_t found = str.find_last_of("/\\");
+	return str.substr(found + 1);
+}
 void FB::Log::trace(std::string src, std::string msg, const char *file, int line, const char *fn)
 {
     LOG4CPLUS_TRACE(log4cplus::Logger::getInstance(L"FireBreath"), 
-                    file << ":" << line << " - " << fn << " - " << FB::utf8_to_wstring(msg));
+		getFilename(file).c_str() << ":" << line << " - " << fn << " - " << FB::utf8_to_wstring(msg));
 }
 void FB::Log::debug(std::string src, std::string msg, const char *file, int line, const char *fn)
 {
     LOG4CPLUS_DEBUG(log4cplus::Logger::getInstance(L"FireBreath"), 
-                    file << ":" << line << " - " << fn << " - " << FB::utf8_to_wstring(msg));
+		getFilename(file).c_str() << ":" << line << " - " << fn << " - " << FB::utf8_to_wstring(msg));
 }
 void FB::Log::info(std::string src, std::string msg, const char *file, int line, const char *fn)
 {
     LOG4CPLUS_INFO(log4cplus::Logger::getInstance(L"FireBreath"), 
-                   file << ":" << line << " - " << fn << " - " << FB::utf8_to_wstring(msg));
+		getFilename(file).c_str() << ":" << line << " - " << fn << " - " << FB::utf8_to_wstring(msg));
 }
 void FB::Log::warn(std::string src, std::string msg, const char *file, int line, const char *fn)
 {
     LOG4CPLUS_WARN(log4cplus::Logger::getInstance(L"FireBreath"), 
-                   file << ":" << line << " - " << fn << " - " << FB::utf8_to_wstring(msg));
+		getFilename(file).c_str() << ":" << line << " - " << fn << " - " << FB::utf8_to_wstring(msg));
 }
 void FB::Log::error(std::string src, std::string msg, const char *file, int line, const char *fn)
 {
     LOG4CPLUS_ERROR(log4cplus::Logger::getInstance(L"FireBreath"), 
-                    file << ":" << line << " - " << fn << " - " << FB::utf8_to_wstring(msg));
+		getFilename(file).c_str() << ":" << line << " - " << fn << " - " << FB::utf8_to_wstring(msg));
 }
 void FB::Log::fatal(std::string src, std::string msg, const char *file, int line, const char *fn)
 {
     LOG4CPLUS_ERROR(log4cplus::Logger::getInstance(L"FireBreath"), 
-                    file << ":" << line << " - " << fn << " - " << FB::utf8_to_wstring(msg));
+		getFilename(file).c_str() << ":" << line << " - " << fn << " - " << FB::utf8_to_wstring(msg));
 }
 


### PR DESCRIPTION
Minor changes to build FB 2.0 on different platforms with more recent tools
- Mac : OS X Yosemite 10.10.5 with Xcode 6.4
- Windows : Visual Studio 2015
- Unix :   Ubuntu 14.04  with cmake 3.2.2 and g++ 5.3.0