### PR TITLE
* Remove replace invalid chars operator in wstring_to_utf8

### DIFF
--- a/src/ScriptingCore/utf8_tools.cpp
+++ b/src/ScriptingCore/utf8_tools.cpp
@@ -36,12 +36,10 @@ namespace FB {
 
     std::string wstring_to_utf8(const std::wstring& src) {
         std::string out_str;
-        std::wstring in_str;
-        utf8::replace_invalid(src.begin(), src.end(), std::back_inserter(in_str));
 #ifdef _WIN32
-        utf8::utf16to8(in_str.begin(), in_str.end(), std::back_inserter(out_str));
+		utf8::utf16to8(src.begin(), src.end(), std::back_inserter(out_str));
 #else
-        utf8::utf32to8(in_str.begin(), in_str.end(), std::back_inserter(out_str));
+		utf8::utf32to8(src.begin(), src.end(), std::back_inserter(out_str));
 #endif
         return out_str;
     }


### PR DESCRIPTION
because it replace all non-ascii character to 0xFFFD, then will break string content.