### PR TITLE
fix build of FBTestPlugin after Promise API change; tested on Windows…

### DIFF
--- a/examples/FBTestPlugin/FBTestPluginAPI.cpp
+++ b/examples/FBTestPlugin/FBTestPluginAPI.cpp
@@ -172,7 +172,15 @@ FB::variant FBTestPluginAPI::fail() {
 FB::variantPromise FBTestPluginAPI::failSlowly() {
     FB::variantDeferred dfd;
 
-    auto callback = [dfd]() { std::this_thread::sleep_for(std::chrono::seconds(2)); dfd.reject(FB::script_error("Slow failure!")); };
+	std::exception_ptr exp;
+	try{
+		throw FB::script_error("Slow failure!");
+	}
+	catch (...)
+	{
+		exp = std::current_exception();
+	}
+    auto callback = [dfd,exp]() { std::this_thread::sleep_for(std::chrono::seconds(2)); dfd.reject(exp); };
 
     std::async(callback);
 

--- a/examples/FBTestPlugin/ThreadRunnerAPI.cpp
+++ b/examples/FBTestPlugin/ThreadRunnerAPI.cpp
@@ -50,9 +50,17 @@ void ThreadRunnerAPI::threadRun()
                     } else if (var.is_of_type<FB::JSObjectPtr>()) {
                         addMethod(var.convert_cast<FB::JSObjectPtr>());
                     }
-                }).fail([host](std::exception ex) -> void {
+                }).fail([host](std::exception_ptr ex) -> void {
                     // The function had an exception
-                    host->htmlLog(std::string("Exception calling func ") + ex.what());
+					try{
+						if (ex)
+							std::rethrow_exception(ex);
+					}
+					catch (std::exception& ex2)
+					{
+						host->htmlLog(std::string("Exception calling func ") + ex2.what());
+					}
+					
                 });
             } catch (const FB::script_error& ex) {
                 // The function call failed


### PR DESCRIPTION
I found that FBTestPlugin build faild on Windows due to a change into FB Promise API. This pull request attempt to fixthe issue in branch 2.0