### PR TITLE
fix crash on Windows/VS2013 all browsers

### DIFF
--- a/examples/FBTestPlugin/FBTestPluginAPI.cpp
+++ b/examples/FBTestPlugin/FBTestPluginAPI.cpp
@@ -435,14 +435,14 @@ void FBTestPluginAPI::timerCallback(const FB::JSObjectPtr& callback)
 }
 
 FB::VariantMap FBTestPluginAPI::systemHelpersTest(){
-    FB::VariantMap result{
-        { "homedir", FB::System::getHomeDirPath() },
-        { "tempdir", FB::System::getTempPath()},
-        { "appdata", FB::System::getAppDataPath("FBTestPlugin")},
-        { "appdata_local", FB::System::getLocalAppDataPath("FBTestPlugin")}
-    };
-    
-    return result;
+
+		FB::VariantMap result;
+		result["homedir"] = FB::System::getHomeDirPath();
+		result["homedir"] = FB::System::getHomeDirPath();
+		result["tempdir"] = FB::System::getTempPath();
+		result["appdata"] = FB::System::getAppDataPath("FBTestPlugin");
+		result["appdata_local"] = FB::System::getLocalAppDataPath("FBTestPlugin");
+		return result;
 }
 
 const boost::optional<std::string> FBTestPluginAPI::optionalTest( std::string test1, const boost::optional<std::string>& str )


### PR DESCRIPTION
I found a crash within FBTestPlugin when compiled on Windows/Visual Studio 2013. This make plugin crash when tested against IE10,Firefox 47 and Safari 5.

To reproduce the crash: open an HTML document that contains:
```
<html>
<head>
</head>
<body>
<object id="plugin0" type="application/x-fbtestplugin" width="100%" height="100%"></object>
<script language="Javascript" type="text/javascript">

  var plugin0 = document.getElementById("plugin0");
  var helper = plugin0.systemHelpersTest()
  helper.then(function(values){
  	console.log(values.homedir)
  })
  
</script>
</body>
</html>
```
function ``systemHelpersTest()`` make browser/plugin_container crash systematically, the CallStack point on ``boost::any::~any()`` dtor.

This PR fix this issue.