### PR TITLE
Fix seg fault if pvarRes is NULL on InvokeEx

### DIFF
--- a/src/ActiveXCore/JSAPI_IDispatchEx.h
+++ b/src/ActiveXCore/JSAPI_IDispatchEx.h
@@ -395,8 +395,11 @@ namespace FB { namespace ActiveX {
                         params.emplace_back(host->getVariant(&pdp->rgvarg[i]));
                     }
                 }
-                
-                setPromise(api->Invoke(wsName, params), pvarRes);
+                FB::variant rVal;
+                rVal = api->Invoke(wsName, params);
+		
+                if(pvarRes)
+			setPromise(api->Invoke(wsName, params), pvarRes);
                 
             } else if (wFlags & DISPATCH_PROPERTYGET && api->HasMethod(wsName)) {
                 


### PR DESCRIPTION
According to the MSDN it is perfectly valid to call InvokeEx with NULL pVarRes:

https://msdn.microsoft.com/ja-jp/library/cc392116.aspx

```
pVarRes
        Pointer to the location where the result is to be stored or Null if the caller expects no result.
```

So the code has to be prepared to handle Null input values. 

In master branch it was already done that way:
```
                FB::variant rVal;
                rVal = api->Invoke(wsName, params);
                
                if(pvarRes)
                    host->getComVariant(pvarRes, rVal);
```
https://github.com/firebreath/FireBreath/blob/master/src/ActiveXCore/JSAPI_IDispatchEx.h#L491

So it is definitively a regresion from master -> 2.0