### PR TITLE
Small WiX update - disabling ICE80 check for light.exe - allowing to …

### DIFF
--- a/cmake/wix.cmake
+++ b/cmake/wix.cmake
@@ -189,7 +189,7 @@ if (WIN32)
     MACRO(WIX_LINK _project _target _sources _loc_files EXTRA_EXTENSIONS)
         #DBG_MSG("WIX command: ${WIX_LIGHT}\n WIX target: ${_target} objs: ${${_sources}}")
 
-        SET( WIX_LINK_FLAGS_A ${WIX_LINK_FLAGS} )
+        SET(WIX_LINK_FLAGS_A ${WIX_LINK_FLAGS} -sice:ICE80)
         SET(EXT_FLAGS -ext WixUtilExtension)
         SET(EXT_FLAGS ${EXT_FLAGS} -ext WixUIExtension)
         FOREACH (CUR_EXT ${EXTRA_EXTENSIONS})

--- a/fbgen/src/Win/WiX/TemplateInstaller.wxs
+++ b/fbgen/src/Win/WiX/TemplateInstaller.wxs
@@ -64,22 +64,28 @@
                                 <File Id="FireWyrmNativeMessageHostExe" Source="$(var.BINSRC)\FireWyrmNativeMessageHost.exe" />
                                 <RegistryValue
                                     Root="HKCU"
-                                    Id="NativeHostManifestRegEntry"
-                                    Key="SOFTWARE\Google\Chrome\NativeMessagingHosts\${PLUGIN_CRX_NATIVEHOST_NAME}"
-                                    Type="string"
-                                    Value="[INSTALLDIR]\${PLUGIN_CRX_NATIVEHOST_NAME}_chrome.json" />
-                                <RegistryValue
-                                    Root="HKCU"
-                                    Id="NativeHostManifestRegEntry"
-                                    Key="SOFTWARE\Mozilla\NativeMessagingHosts\${PLUGIN_CRX_NATIVEHOST_NAME}"
-                                    Type="string"
-                                    Value="[INSTALLDIR]\${PLUGIN_CRX_NATIVEHOST_NAME}_mozilla.json" />
-                                <RegistryValue
-                                    Root="HKCU"
                                     Key="SOFTWARE\${COMPANY_NAME}\${PLUGIN_NAME}"
                                     Name="ManifestInstalled"
                                     Type="string"
                                     Value="true"
+                                    KeyPath="yes" />
+                            </Component>
+                            <Component Id="NativeMessageChromeRegistry" Guid="{409DA06C-5DF9-44F2-9166-146EF5FF9554}">
+                                <RegistryValue
+                                    Root="HKCU"
+                                    Id="NativeHostChromeManifestRegEntry"
+                                    Key="SOFTWARE\Google\Chrome\NativeMessagingHosts\${PLUGIN_CRX_NATIVEHOST_NAME}"
+                                    Type="string"
+                                    Value="[INSTALLDIR]\${PLUGIN_CRX_NATIVEHOST_NAME}_chrome.json"
+                                    KeyPath="yes" />
+                            </Component>
+                            <Component Id="NativeMessageMozillaRegistry" Guid="{D6D3F029-E3B9-477F-B999-DE12CAD9EE6C}" Win64="yes">
+                                <RegistryValue
+                                    Root="HKCU"
+                                    Id="NativeHostMozillaManifestRegEntry"
+                                    Key="SOFTWARE\Mozilla\NativeMessagingHosts\${PLUGIN_CRX_NATIVEHOST_NAME}"
+                                    Type="string"
+                                    Value="[INSTALLDIR]\${PLUGIN_CRX_NATIVEHOST_NAME}_mozilla.json"
                                     KeyPath="yes" />
                             </Component>
 
@@ -102,6 +108,8 @@
             <ComponentRef Id="CompanyDirComp"/>
             <ComponentGroupRef Id="PluginDLLGroup"/>
             <ComponentRef Id="FireWyrmNativeMessageHost"/>
+            <ComponentRef Id="NativeMessageChromeRegistry"/>
+            <ComponentRef Id="NativeMessageMozillaRegistry"/>
         </Feature>
     </Product>
 </Wix>


### PR DESCRIPTION
Hi Richard, 

When I tried your WiX changes in my dev machine it all worked well... But after trying deployment - and using MSI file on a separate machine (64 bit) it occured that MSI installs registry entries under:
 - HKLM/HKCU -> Software -> Wow6432Node -> Mozilla -> NativeMessagingHosts

And for some reason both 32 and 64 bit Firefoxes are not reading it - instead both reads 64bit path:
 - HKLM/HKCU -> Software -> Mozilla -> NativeMessagingHosts

So the solution would be to write to 64 paths - while keeping everything else in 32 bit paths - as it was. I found this: http://stackoverflow.com/questions/6191591/how-can-wix-based-installers-do-com-registration-for-both-32-and-64-bit-windows

I had to add -sice:ICE80 parameter to light.exe - which works fine - I recreated and rebuilded my project with it.

I also changed your WiX template to make RegistryValue in their own Component - and Firefox one marked as Win64="yes" - I'm not using this template - so please review it yourself... 

I guess I'm not missing anything - leaving this changes as pull-request for now. 