### PR TITLE
Added generic Visual Studio prep script for VS2017

### DIFF
--- a/prepVisualStudio.cmd
+++ b/prepVisualStudio.cmd
@@ -1,0 +1,34 @@
+@echo off & setlocal enableextensions enabledelayedexpansion
+
+REM check if 1st parameter is Visual Studio cmake generator name
+echo "%~1" | findstr /c:"Visual Studio" >nul 
+if not %errorlevel% == 0  goto args_count_wrong 
+goto args_count_ok
+
+:args_count_wrong
+REM Show usage message and list available Visual Studio cmake generators
+echo Usage %0 "visual studio cmake generator" [project dir] [build dir]  
+echo The available Visual Studio cmake generators are : 
+cmake --help | FINDSTR "Visual Optional"
+exit /b 1
+
+:args_count_ok
+REM set generator 
+set _FB_GEN="%~1"
+
+REM store current dir in var cur_dir so it can be used after shift 
+set cur_dir=%~d0%~p0
+
+REM store all arguments except 1st (cmake generator name) in RESTVAR variable.
+shift
+:loop1
+if "%~1"=="" goto after_loop
+set RESTVAR=%RESTVAR% "%~1"
+shift
+goto loop1
+:after_loop
+
+call "%cur_dir%\common.cmd" %RESTVAR%
+if %errorlevel% == 2 exit /b 1
+call "%cur_dir%\winprep.cmd"
+

--- a/prepVisualStudio.cmd
+++ b/prepVisualStudio.cmd
@@ -15,20 +15,9 @@ exit /b 1
 :args_count_ok
 REM set generator 
 set _FB_GEN="%~1"
+set ALL_ARG=%*
+call set ALL_BUT_FIRST_ARG=%%ALL_ARG:%_FB_GEN%=%%
 
-REM store current dir in var cur_dir so it can be used after shift 
-set cur_dir=%~d0%~p0
-
-REM store all arguments except 1st (cmake generator name) in RESTVAR variable.
-shift
-:loop1
-if "%~1"=="" goto after_loop
-set RESTVAR=%RESTVAR% "%~1"
-shift
-goto loop1
-:after_loop
-
-call "%cur_dir%\common.cmd" %RESTVAR%
+call "%~d0%~p0\common.cmd" %ALL_BUT_FIRST_ARG%
 if %errorlevel% == 2 exit /b 1
-call "%cur_dir%\winprep.cmd"
-
+call "%~d0%~p0\winprep.cmd"


### PR DESCRIPTION
Added prepVisualStudio.cmd that can be used for Visual Studio 2017 builds. 
Running it  without parameters gives list of available Visual studio templates in cmake,
```
.\firebreath\prepVisualStudio.cmd
Usage .\firebreath\prepVisualStudio.cmd "visual studio cmake generator" [project dir] [build dir]
The available Visual Studio cmake generators are :
  Visual Studio 15 2017 [arch] = Generates Visual Studio 2017 project files.
                                 Optional [arch] can be "Win64" or "ARM".
  Visual Studio 14 2015 [arch] = Generates Visual Studio 2015 project files.
                                 Optional [arch] can be "Win64" or "ARM".
  Visual Studio 12 2013 [arch] = Generates Visual Studio 2013 project files.
                                 Optional [arch] can be "Win64" or "ARM".
  Visual Studio 11 2012 [arch] = Generates Visual Studio 2012 project files.
                                 Optional [arch] can be "Win64" or "ARM".
  Visual Studio 10 2010 [arch] = Generates Visual Studio 2010 project files.
                                 Optional [arch] can be "Win64" or "IA64".
  Visual Studio 9 2008 [arch]  = Generates Visual Studio 2008 project files.
                                 Optional [arch] can be "Win64" or "IA64".
  Visual Studio 8 2005 [arch]  = Generates Visual Studio 2005 project files.
                                 Optional [arch] can be "Win64".
  Visual Studio 7 .NET 2003    = Deprecated.  Generates Visual Studio .NET
```
You just add the appropriate one for your Visual Studio version as an argument.
For example to build plugin with Visual Studio 2017 call : 
`.\firebreath\prepVisualStudio.cmd "Visual Studio 15 2017" . build
`
